### PR TITLE
fixed bugs in StorageHiveCluster: Not support in clause

### DIFF
--- a/src/DataTypes/NestedUtils.cpp
+++ b/src/DataTypes/NestedUtils.cpp
@@ -106,7 +106,7 @@ Block flatten(const Block & block)
                     res.insert(ColumnWithTypeAndName(
                         is_const
                             ? ColumnConst::create(std::move(column_array_of_element), block.rows())
-                            : std::move(column_array_of_element),
+                            : column_array_of_element,
                         std::make_shared<DataTypeArray>(element_types[i]),
                         nested_name));
                 }
@@ -121,7 +121,7 @@ Block flatten(const Block & block)
                 const DataTypes & element_types = type_tuple->getElements();
                 const Strings & names = type_tuple->getElementNames();
                 const ColumnTuple * column_tuple;
-                if(isColumnConst(*elem.column))
+                if (isColumnConst(*elem.column))
                     column_tuple = typeid_cast<const ColumnTuple *>(&assert_cast<const ColumnConst &>(*elem.column).getDataColumn());
                 else
                     column_tuple = typeid_cast<const ColumnTuple *>(elem.column.get());

--- a/src/DataTypes/NestedUtils.h
+++ b/src/DataTypes/NestedUtils.h
@@ -36,7 +36,7 @@ namespace Nested
     std::unordered_set<String> getAllTableNames(const Block & block, bool to_lower_case = false);
 }
 
-/// Use this class to extract element columns from columns of nested type in a block, e.g. named Tuple. 
+/// Use this class to extract element columns from columns of nested type in a block, e.g. named Tuple.
 /// It can extract a column from a multiple nested type column, e.g. named Tuple in named Tuple
 /// Keeps some intermediate datas to avoid rebuild them multi-times.
 class NestedColumnExtractHelper

--- a/src/Storages/Hive/StorageHiveCluster.cpp
+++ b/src/Storages/Hive/StorageHiveCluster.cpp
@@ -1,7 +1,4 @@
 #include <Storages/Hive/StorageHiveCluster.h>
-#include "Parsers/ASTSelectQuery.h"
-#include "Parsers/IAST_fwd.h"
-#include "QueryPipeline/QueryPipeline.h"
 
 #if USE_HIVE
 #include <algorithm>
@@ -74,11 +71,9 @@ void StorageHiveCluster::read(
     size_t max_block_size_,
     unsigned num_streams_)
 {
-    //auto query_kind = context_->getClientInfo().query_kind;
 
     auto policy_name = context_->getSettings().getString("hive_cluster_task_iterate_policy");
     // first stage. create remote executors pipeline
-    //if (is_remote && query_kind == ClientInfo::QueryKind::INITIAL_QUERY)
     if (is_remote)
     {
         auto iterate_callback_builder = HiveSourceCollectCallbackFactory::instance().getCallback(policy_name);

--- a/src/Storages/Hive/StorageHiveCluster.cpp
+++ b/src/Storages/Hive/StorageHiveCluster.cpp
@@ -1,4 +1,7 @@
 #include <Storages/Hive/StorageHiveCluster.h>
+#include "Parsers/ASTSelectQuery.h"
+#include "Parsers/IAST_fwd.h"
+#include "QueryPipeline/QueryPipeline.h"
 
 #if USE_HIVE
 #include <algorithm>
@@ -9,6 +12,7 @@
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Interpreters/SelectQueryOptions.h>
 #include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTFunction.h>
 #include <Parsers/queryToString.h>
 #include <Processors/Sources/RemoteSource.h>
 #include <Processors/QueryPlan/QueryPlan.h>
@@ -19,6 +23,7 @@
 #include <Storages/Hive/StorageHive.h>
 #include <Storages/StorageFactory.h>
 #include <Storages/AlterCommands.h>
+#include <TableFunctions/Hive/TableFunctionHiveCluster.h>
 namespace DB
 {
 
@@ -40,7 +45,8 @@ StorageHiveCluster::StorageHiveCluster(
     const String & comment_,
     const ASTPtr & partition_by_ast_,
     std::unique_ptr<HiveSettings> storage_settings_,
-    ContextPtr context_)
+    ContextPtr context_,
+    bool is_remote_)
     : IStorage(table_id_)
     , WithContext(context_)
     , cluster_name(cluster_name_)
@@ -49,6 +55,7 @@ StorageHiveCluster::StorageHiveCluster(
     , hive_table(hive_table_)
     , partition_by_ast(partition_by_ast_)
     , storage_settings(std::move(storage_settings_))
+    , is_remote(is_remote_)
 {
     StorageInMemoryMetadata storage_metadata;
     storage_metadata.setColumns(columns_);
@@ -67,11 +74,12 @@ void StorageHiveCluster::read(
     size_t max_block_size_,
     unsigned num_streams_)
 {
-    auto query_kind = context_->getClientInfo().query_kind;
+    //auto query_kind = context_->getClientInfo().query_kind;
 
     auto policy_name = context_->getSettings().getString("hive_cluster_task_iterate_policy");
     // first stage. create remote executors pipeline
-    if (query_kind == ClientInfo::QueryKind::INITIAL_QUERY)
+    //if (is_remote && query_kind == ClientInfo::QueryKind::INITIAL_QUERY)
+    if (is_remote)
     {
         auto iterate_callback_builder = HiveSourceCollectCallbackFactory::instance().getCallback(policy_name);
         if (!iterate_callback_builder)
@@ -100,6 +108,8 @@ void StorageHiveCluster::read(
         Pipes pipes;
         const bool add_agg_info = processed_stage_ == QueryProcessingStage::WithMergeableState;
 
+        auto query_str = queryToString(rewriteQuery(query_info_.query));
+
         for (const auto & replicas : cluster->getShardsAddresses())
         {
             for (const auto & node : replicas)
@@ -119,12 +129,12 @@ void StorageHiveCluster::read(
                 auto task_iter_callback = std::make_shared<TaskIterator>([node]() { return node.host_name; });
                 auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(
                     connection,
-                    queryToString(query_info_.original_query),
+                    query_str,
                     header,
                     context_,
                     nullptr,
                     scalars,
-                    Tables(),
+                    context_->getExternalTables(),
                     processed_stage_,
                     RemoteQueryExecutor::Extension{.task_iterator = (*iterate_callback_builder)->buildCollectCallback(node)});
                 pipes.emplace_back(std::make_shared<RemoteSource>(remote_query_executor, add_agg_info, false));
@@ -205,6 +215,45 @@ void StorageHiveCluster::alter(const AlterCommands & params, ContextPtr local_co
     params.apply(new_metadata, local_context);
     DatabaseCatalog::instance().getDatabase(table_id.database_name)->alterTable(local_context, table_id, new_metadata);
     setInMemoryMetadata(new_metadata);
+}
+
+/// Replace the table( or table function) with new table function `hiveClusterLocalShard`, so the remote node
+/// will use Context::getReadTaskCallback() to get assigned tasks from this node.
+ASTPtr StorageHiveCluster::rewriteQuery(const ASTPtr & query)
+{
+    auto select_query_ref = query->clone();
+    auto * select_query = select_query_ref->as<ASTSelectQuery>();
+
+
+    auto table_func = std::make_shared<ASTFunction>();
+    table_func->name = TableFunctionHivClusterLocalShard::name;
+    table_func->arguments = std::make_shared<ASTExpressionList>();
+    table_func->children.push_back(table_func->arguments);
+
+    table_func->arguments->children.push_back(std::make_shared<ASTLiteral>(Field(cluster_name)));
+    table_func->arguments->children.push_back(std::make_shared<ASTLiteral>(Field(hive_metastore_url)));
+    table_func->arguments->children.push_back(std::make_shared<ASTLiteral>(Field(hive_database)));
+    table_func->arguments->children.push_back(std::make_shared<ASTLiteral>(Field(hive_table)));
+
+    auto metadata_snapshot = getInMemoryMetadataPtr();
+    WriteBufferFromOwnString struct_buf;
+    int i = 0;
+    for (const auto & name_and_type : metadata_snapshot->getColumns().getAllPhysical())
+    {
+        if (i)
+            struct_buf << ",";
+        struct_buf << name_and_type.name << " " << name_and_type.type->getName();
+        i++;
+    }
+    auto hash_table_structure = std::make_shared<ASTLiteral>(struct_buf.str());
+    table_func->arguments->children.push_back(hash_table_structure);
+
+    auto partition_key = std::make_shared<ASTLiteral>(queryToString(partition_by_ast));
+    table_func->arguments->children.push_back(partition_key);
+
+    auto table_function_ast = table_func->clone();
+    select_query->addTableFunction(table_function_ast);
+    return select_query_ref;
 }
 
 void registerStorageHiveCluster(StorageFactory & factory_)

--- a/src/Storages/Hive/StorageHiveCluster.h
+++ b/src/Storages/Hive/StorageHiveCluster.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Common/config.h>
+#include "Parsers/IAST_fwd.h"
 #if USE_HIVE
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionAnalyzer.h>
@@ -35,7 +36,8 @@ public:
         const String & comment_,
         const ASTPtr & partition_by_ast_,
         std::unique_ptr<HiveSettings> storage_settings_,
-        ContextPtr context_);
+        ContextPtr context_,
+        bool is_remote_ = true);
 
     String getName() const override { return "HiveCluster"; }
     bool supportsIndexForIn() const override { return true; }
@@ -48,7 +50,8 @@ public:
         return true;
     }
 
-    bool isRemote() const override { return true; }
+    //bool isRemote() const override { return true; }
+    bool isRemote() const override { return is_remote; }
 
     void read(
         QueryPlan & query_plan_,
@@ -76,7 +79,13 @@ private:
 
     std::shared_ptr<HiveSettings> storage_settings;
 
+    /// It's false when it's a storage instance created by table function 'hiveClusterLocalShard'
+    /// and in the read() use Context::getReadTaskCallback() to get tasks from the initiator node
+    bool is_remote;
+
     Poco::Logger * logger = &Poco::Logger::get("StorageHiveCluster");
+
+    ASTPtr rewriteQuery(const ASTPtr & original_query);
 };
 }
 

--- a/src/Storages/Hive/StorageHiveCluster.h
+++ b/src/Storages/Hive/StorageHiveCluster.h
@@ -37,7 +37,7 @@ public:
         const ASTPtr & partition_by_ast_,
         std::unique_ptr<HiveSettings> storage_settings_,
         ContextPtr context_,
-        bool is_remote_ = true);
+        bool is_remote_);
 
     String getName() const override { return "HiveCluster"; }
     bool supportsIndexForIn() const override { return true; }

--- a/src/Storages/Hive/StorageHiveCluster.h
+++ b/src/Storages/Hive/StorageHiveCluster.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <Common/config.h>
-#include "Parsers/IAST_fwd.h"
+
 #if USE_HIVE
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionAnalyzer.h>
@@ -50,7 +50,6 @@ public:
         return true;
     }
 
-    //bool isRemote() const override { return true; }
     bool isRemote() const override { return is_remote; }
 
     void read(

--- a/src/TableFunctions/Hive/TableFunctionHiveCluster.cpp
+++ b/src/TableFunctions/Hive/TableFunctionHiveCluster.cpp
@@ -80,7 +80,8 @@ StoragePtr TableFunctionHiveCluster::executeImpl(
         "",
         partition_by_ast,
         std::make_unique<HiveSettings>(),
-        context_);
+        context_,
+        true);
 
     return storage;
 }

--- a/src/TableFunctions/Hive/TableFunctionHiveCluster.cpp
+++ b/src/TableFunctions/Hive/TableFunctionHiveCluster.cpp
@@ -85,10 +85,74 @@ StoragePtr TableFunctionHiveCluster::executeImpl(
     return storage;
 }
 
+void TableFunctionHivClusterLocalShard::parseArguments(const ASTPtr & ast_function_, ContextPtr context_)
+{
+    ASTs & args_func = ast_function_->children;
+    if (args_func.size() != 1)
+        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Table function '{}' must have arguments.", getName());
+
+    ASTs & args = args_func.at(0)->children;
+
+    const auto message = fmt::format(
+        "The signature of function {} is:\n"
+        " - cluster_name, hive_url, hive_database, hive_table, structure, partition_by_keys",
+        getName());
+
+    if (args.size() != 6)
+        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, message);
+
+    for (auto & arg : args)
+        arg = evaluateConstantExpressionOrIdentifierAsLiteral(arg, context_);
+
+    cluster_name = args[0]->as<ASTLiteral &>().value.safeGet<String>();
+    hive_metastore_url = args[1]->as<ASTLiteral &>().value.safeGet<String>();
+    hive_database = args[2]->as<ASTLiteral &>().value.safeGet<String>();
+    hive_table = args[3]->as<ASTLiteral &>().value.safeGet<String>();
+    table_structure = args[4]->as<ASTLiteral &>().value.safeGet<String>();
+    partition_by_def = args[5]->as<ASTLiteral &>().value.safeGet<String>();
+
+    actual_columns = parseColumnsListFromString(table_structure, context_);
+}
+
+ColumnsDescription TableFunctionHivClusterLocalShard::getActualTableStructure(ContextPtr /*context_*/) const
+{
+    return actual_columns;
+}
+
+StoragePtr TableFunctionHivClusterLocalShard::executeImpl(
+    const ASTPtr & /*ast_function_*/, ContextPtr context_, const std::string & table_name_, ColumnsDescription /*cached_columns_*/) const
+{
+    const Settings & settings = context_->getSettings();
+    ParserLambdaExpression partition_by_parser;
+    ASTPtr partition_by_ast = parseQuery(
+        partition_by_parser,
+        "(" + partition_by_def + ")",
+        "partition by declaration list",
+        settings.max_query_size,
+        settings.max_parser_depth);
+    StoragePtr storage;
+    storage = std::make_shared<StorageHiveCluster>(
+        cluster_name,
+        hive_metastore_url,
+        hive_database,
+        hive_table,
+        StorageID(getDatabaseName(), table_name_),
+        actual_columns,
+        ConstraintsDescription{},
+        "",
+        partition_by_ast,
+        std::make_unique<HiveSettings>(),
+        context_,
+        false);
+
+    return storage;
+}
+
 
 void registerTableFunctionHiveCluster(TableFunctionFactory & factory_)
 {
     factory_.registerFunction<TableFunctionHiveCluster>();
+    factory_.registerFunction<TableFunctionHivClusterLocalShard>();
 }
 }
 #endif

--- a/src/TableFunctions/Hive/TableFunctionHiveCluster.h
+++ b/src/TableFunctions/Hive/TableFunctionHiveCluster.h
@@ -40,7 +40,7 @@ private:
     ColumnsDescription actual_columns;
 };
 
-/// For quering remote shards of the hive cluster table 
+/// For quering remote shards of the hive cluster table
 class TableFunctionHivClusterLocalShard : public ITableFunction
 {
 public:

--- a/src/TableFunctions/Hive/TableFunctionHiveCluster.h
+++ b/src/TableFunctions/Hive/TableFunctionHiveCluster.h
@@ -39,6 +39,37 @@ private:
 
     ColumnsDescription actual_columns;
 };
+
+/// For quering remote shards of the hive cluster table 
+class TableFunctionHivClusterLocalShard : public ITableFunction
+{
+public:
+    static constexpr auto name = "hiveClusterLocalShard";
+    static constexpr auto storage_type_name = "HiveCluster";
+    std::string getName() const override { return name; }
+
+    bool hasStaticStructure() const override { return true; }
+
+    StoragePtr executeImpl(
+        const ASTPtr & ast_function, ContextPtr context, const std::string & table_name, ColumnsDescription cached_columns) const override;
+
+    const char * getStorageTypeName() const override { return storage_type_name; }
+    ColumnsDescription getActualTableStructure(ContextPtr) const override;
+    void parseArguments(const ASTPtr & ast_function_, ContextPtr context_) override;
+
+private:
+    Poco::Logger * logger = &Poco::Logger::get("TableFunctionHivClusterLocalShard");
+
+    String cluster_name;
+    String hive_metastore_url;
+    String hive_database;
+    String hive_table;
+    String table_structure;
+    String partition_by_def;
+
+    ColumnsDescription actual_columns;
+
+};
 }
 
 #endif


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in official stable or prestable release)



### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...
Support `in ` clause now as following
```SQL

select msgid from hive_cluster_storage1 where uid in (select uid in hive_cluster_storage2)

```


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
