### PR TITLE
fix cann't schedule issue when query hive table without partition

### DIFF
--- a/src/Storages/Hive/HiveFilesCollector.cpp
+++ b/src/Storages/Hive/HiveFilesCollector.cpp
@@ -98,7 +98,7 @@ HiveFiles HiveFilesCollector::collect(HivePruneLevel prune_level)
         auto file_infos = hive_table_metadata->getFilesByLocation(hdfs_fs, hive_table_metadata->getTable()->sd.location);
         for (const auto & file_info : file_infos)
         {
-            thread_pool.scheduleOrThrow([&]()
+            thread_pool.scheduleOrThrowOnError([&]()
             {
                 auto hive_file = getHiveFileIfNeeded(file_info, {}, hive_table_metadata, prune_level);
                 if (hive_file)


### PR DESCRIPTION
复现过程
```
CREATE TABLE bigolive.user_countrycode_hivequery
(
    `uid` Int64,
    `countrycode` String
)
ENGINE = HiveCluster('hive_sg', 'host:9083', 'bigolive', 'user_countrycode')
PARTITION BY tuple()  
```


```
sg-s3-ch012.bigdata.bigo.inner :) SELECT uid,countrycode from bigolive.user_countrycode_hivequery limit 1000

SELECT
    uid,
    countrycode
FROM bigolive.user_countrycode_hivequery
LIMIT 1000

Query id: f70a0adc-ac6e-4e10-87fb-12a8e6f2ff5b


0 rows in set. Elapsed: 0.157 sec. 

Received exception from server (version 22.7.1):
Code: 439. DB::Exception: Received from 10.152.34.212:9001. DB::Exception: Cannot schedule a task: no free thread (timeout=0) (threads=1, jobs=1). (CANNOT_SCHEDULE_TASK)


```

